### PR TITLE
dune: fix dependency on atdgen-runtime

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (executable
   (name es)
   (public_name es)
-  (libraries atdgen cmdliner devkit extlib re2)
+  (libraries atdgen-runtime cmdliner devkit extlib re2)
   (modules :standard \ gen_version)
   (preprocess (pps lwt_ppx ppx_let)))
 


### PR DESCRIPTION
> atdgen: The deprecated atdgen library is no longer available. Use atdgen-runtime instead (#421)
https://github.com/ahrefs/atd/blob/master/CHANGES.md